### PR TITLE
Added the possibility to choose between transparent and non-transparent text

### DIFF
--- a/Classes/RSMaskedLabel.h
+++ b/Classes/RSMaskedLabel.h
@@ -10,4 +10,6 @@
 
 @interface RSMaskedLabel : UILabel
 
+@property (nonatomic) BOOL transparencyIsEnabled;
+
 @end

--- a/Classes/RSMaskedLabel.m
+++ b/Classes/RSMaskedLabel.m
@@ -15,7 +15,7 @@
 
 @implementation RSMaskedLabel
 {
-	UIColor* maskedBackgroundColor;
+    UIColor* maskedBackgroundColor;
 }
 
 - (id)initWithFrame:(CGRect)frame
@@ -34,42 +34,54 @@
 
 - (UIColor*) backgroundColor
 {
-	return maskedBackgroundColor;
+    return maskedBackgroundColor;
 }
 
 - (void) setBackgroundColor:(UIColor *)backgroundColor
 {
-	maskedBackgroundColor = backgroundColor;
-	[self setNeedsDisplay];
+    maskedBackgroundColor = backgroundColor;
+    [self setNeedsDisplay];
 }
 
 - (void)RS_commonInit
 {
-	maskedBackgroundColor = [super backgroundColor];
+    maskedBackgroundColor = [super backgroundColor];
     [super setTextColor:[UIColor whiteColor]];
     [super setBackgroundColor:[UIColor clearColor]];
     [self setOpaque:NO];
+    self.transparencyIsEnabled = YES;
 }
 
 - (void)setTextColor:(UIColor *)textColor
 {
     // text color needs to be white for masking to work
+    if (!self.transparencyIsEnabled) {
+        
+        [super setTextColor:textColor];
+    }
 }
 
 - (void)drawRect:(CGRect)rect
 {
+    
+    if (!self.transparencyIsEnabled) {
+        
+        [super drawRect:rect];
+        return;
+    }
+    
     // Render into a temporary bitmap context at a max of 8 bits per component for subsequent CGImageMaskCreate operations
     UIGraphicsBeginImageContextWithOptions(rect.size, false, 0.0);
-
+    
     [super drawRect:rect];
-
+    
     CGContextRef context = UIGraphicsGetCurrentContext();
     CGImageRef image = CGBitmapContextCreateImage(context);
     UIGraphicsEndImageContext();
     
     // Revert to normal graphics context for the rest of the rendering
     context = UIGraphicsGetCurrentContext();
-
+    
     CGContextConcatCTM(context, CGAffineTransformMake(1, 0, 0, -1, 0, CGRectGetHeight(rect)));
     
     // create a mask from the normally rendered text
@@ -82,14 +94,14 @@
     
     CGContextSaveGState(context);
     CGContextClipToMask(context, rect, mask);
-
-	if (self.layer.cornerRadius != 0.0f) {
+    
+    if (self.layer.cornerRadius != 0.0f) {
         CGPathRef path = CGPathCreateWithRoundedRect(rect, self.layer.cornerRadius, self.layer.cornerRadius, nil);
-		CGContextAddPath(context, path);
-		CGContextClip(context);
+        CGContextAddPath(context, path);
+        CGContextClip(context);
         CGPathRelease(path);
-	}
-
+    }
+    
     CFRelease(mask); mask = NULL;
     
     [self RS_drawBackgroundInRect:rect];
@@ -102,7 +114,7 @@
     // this is where you do whatever fancy drawing you want to do!
     CGContextRef context = UIGraphicsGetCurrentContext();
     
-	[maskedBackgroundColor set];
+    [maskedBackgroundColor set];
     CGContextFillRect(context, rect);
 }
 


### PR DESCRIPTION
I created a property named `transparencyIsEnabled`. When set to `NO`, it doesn't perform the custom drawings and the label behaves as a regular `UILabel`. I made these changes because I had to use this class in a `UICollectionView` in which some cells needed to show a `UILabel` with transparent text and some other show regular labels. Screenshot provided for clarification.

![img_2894](https://user-images.githubusercontent.com/469519/27059072-18e3dc02-4fab-11e7-9cef-a7286f9c6be9.PNG)
