### PR TITLE
Master

### DIFF
--- a/Classes/RSMaskedLabel.m
+++ b/Classes/RSMaskedLabel.m
@@ -74,6 +74,7 @@
 - (void)drawRect:(CGRect)rect
 {
     if (!self.isMaskedTextEnabled) {
+        [self RS_drawBackgroundInRect:rect];
         [super drawRect:rect];
         return;
     }


### PR DESCRIPTION
When rendering without masking the background color was not getting
drawn as the backgroundColor hides the super class backgroundColor.  I
tried to first just set the backgroundColor of the super prior to the
super drawRect however that had no effect.  Calling the internal
drawBackground to fill onto the context prior gave the expected results.